### PR TITLE
feat : create query params which identify new one & member quit feature

### DIFF
--- a/server/src/main/java/com/book/village/server/auth/filter/JwtVerificationFilter.java
+++ b/server/src/main/java/com/book/village/server/auth/filter/JwtVerificationFilter.java
@@ -2,6 +2,8 @@ package com.book.village.server.auth.filter;
 
 import com.book.village.server.auth.jwt.JwtTokenizer;
 import com.book.village.server.auth.utils.CustomAuthorityUtils;
+import com.book.village.server.domain.member.entity.Member;
+import com.book.village.server.domain.member.service.MemberService;
 import com.book.village.server.global.exception.CustomLogicException;
 import com.book.village.server.global.exception.ExceptionCode;
 import io.jsonwebtoken.Claims;
@@ -30,11 +32,13 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
     private final JwtTokenizer jwtTokenizer;
     private final CustomAuthorityUtils authorityUtils;
     private final RedisTemplate redisTemplate;
+    private final MemberService memberService;
 
-    public JwtVerificationFilter(JwtTokenizer jwtTokenizer, CustomAuthorityUtils authorityUtils, RedisTemplate redisTemplate) {
+    public JwtVerificationFilter(JwtTokenizer jwtTokenizer, CustomAuthorityUtils authorityUtils, RedisTemplate redisTemplate,MemberService memberService) {
         this.jwtTokenizer = jwtTokenizer;
         this.authorityUtils = authorityUtils;
         this.redisTemplate = redisTemplate;
+        this.memberService = memberService;
     }
 
     @Override
@@ -42,6 +46,7 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
         try {
             Map<String, Object> claims = verifyJws(request);
             verifyLogoutToken(request);
+            verifyActiveMember(claims);
             setAuthenticationToContext(claims);
         } catch (SignatureException se) {
             throw new CustomLogicException(ExceptionCode.TOKEN_INVALID);
@@ -75,6 +80,12 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
 
         if (email != null) {
             throw new Exception();
+        }
+    }
+    private void verifyActiveMember(Map<String, Object> claims){
+        String username = (String) claims.get("username");
+        if(memberService.findMember(username).getMemberStatus()== Member.MemberStatus.MEMBER_QUIT){
+            throw new CustomLogicException(ExceptionCode.MEMBER_STATUS_QUIT);
         }
     }
 

--- a/server/src/main/java/com/book/village/server/auth/handler/OAuth2MemberSuccessHandler.java
+++ b/server/src/main/java/com/book/village/server/auth/handler/OAuth2MemberSuccessHandler.java
@@ -44,22 +44,13 @@ public class OAuth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHa
         var oAuth2User = (OAuth2User)authentication.getPrincipal();
         String email = String.valueOf(oAuth2User.getAttributes().get("email"));
         List<String> authorities = authorityUtils.createRoles(email);
-
-        saveMember(email);
-        redirect(request, response, email, authorities);
-    }
-    private void saveMember(String email) {
         if(!memberRepository.findByEmail(email).isPresent()){
             Member member = new Member(email);
             memberService.createMember(member);
+            redirect(request,response,email, authorities, true);
+            return;
         }
-    }
-    private void redirect(HttpServletRequest request, HttpServletResponse response, String username, List<String> authorities) throws IOException {
-        String accessToken = delegateAccessToken(username, authorities);
-        String refreshToken = delegateRefreshToken(username);
-
-        String uri = createURI(accessToken, refreshToken).toString();
-        getRedirectStrategy().sendRedirect(request, response, uri);
+        redirect(request,response,email, authorities, false);
     }
     private String delegateAccessToken(String username, List<String> authorities) {
         Map<String, Object> claims = new HashMap<>();
@@ -91,16 +82,26 @@ public class OAuth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHa
         return refreshToken;
     }
 
-    private URI createURI(String accessToken, String refreshToken) {
+    private void redirect(HttpServletRequest request, HttpServletResponse response, String username, List<String> authorities, boolean newbie) throws IOException {
+        String accessToken = delegateAccessToken(username, authorities);
+        String refreshToken = delegateRefreshToken(username);
+
+        String uri = createURI(accessToken, refreshToken, newbie).toString();
+        getRedirectStrategy().sendRedirect(request, response, uri);
+    }
+
+    private URI createURI(String accessToken, String refreshToken, boolean newbie) {
         MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         queryParams.add("access_token", accessToken);
         queryParams.add("refresh_token", refreshToken);
+        if(newbie) queryParams.add("membership", "new");
+        else queryParams.add("membership","existing");
 
         return UriComponentsBuilder
                 .newInstance()
                 .scheme("http")
                 .host("bookvillage.kro.kr")
-                .path("/shareList.js")
+                .path("/main")
                 .queryParams(queryParams)
                 .build()
                 .toUri();

--- a/server/src/main/java/com/book/village/server/auth/handler/OAuth2MemberSuccessHandler.java
+++ b/server/src/main/java/com/book/village/server/auth/handler/OAuth2MemberSuccessHandler.java
@@ -7,6 +7,8 @@ import com.book.village.server.auth.utils.CustomAuthorityUtils;
 import com.book.village.server.domain.member.entity.Member;
 import com.book.village.server.domain.member.repository.MemberRepository;
 import com.book.village.server.domain.member.service.MemberService;
+import com.book.village.server.global.exception.CustomLogicException;
+import com.book.village.server.global.exception.ExceptionCode;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;

--- a/server/src/main/java/com/book/village/server/config/SecurityConfiguration.java
+++ b/server/src/main/java/com/book/village/server/config/SecurityConfiguration.java
@@ -97,7 +97,7 @@ public class SecurityConfiguration {
         public void configure(HttpSecurity builder) throws Exception {
             AuthExceptionHandlerFilter authExceptionHandlerFilter = new AuthExceptionHandlerFilter();
             builder.addFilterBefore(authExceptionHandlerFilter, LogoutFilter.class);
-            JwtVerificationFilter jwtVerificationFilter = new JwtVerificationFilter(jwtTokenizer, authorityUtils,redisTemplate);
+            JwtVerificationFilter jwtVerificationFilter = new JwtVerificationFilter(jwtTokenizer, authorityUtils,redisTemplate, memberService);
             builder.addFilterAfter(jwtVerificationFilter, OAuth2LoginAuthenticationFilter.class);
         }
     }

--- a/server/src/main/java/com/book/village/server/domain/member/controller/MemberController.java
+++ b/server/src/main/java/com/book/village/server/domain/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import com.book.village.server.domain.member.mapper.MemberMapper;
 import com.book.village.server.domain.member.service.MemberService;
 import com.book.village.server.global.response.MessageResponseDto;
 import com.book.village.server.global.response.SingleResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -48,5 +49,11 @@ public class MemberController {
         Member member = memberService.findMember(principal.getName());
         memberService.updateMember(member, memberMapper.patchMemberDtoToMember(memberDto));
         return ResponseEntity.ok(new SingleResponse<>(memberMapper.memberToResponseMemberDto(member)));
+    }
+
+    @PatchMapping("/quit")
+    public ResponseEntity quitMember(Principal principal){
+        memberService.quitMember(principal.getName());
+        return ResponseEntity.ok(new MessageResponseDto("quit member!"));
     }
 }

--- a/server/src/main/java/com/book/village/server/domain/member/dto/MemberDto.java
+++ b/server/src/main/java/com/book/village/server/domain/member/dto/MemberDto.java
@@ -1,5 +1,6 @@
 package com.book.village.server.domain.member.dto;
 
+import com.book.village.server.domain.member.entity.Member;
 import lombok.*;
 
 import javax.validation.constraints.Pattern;
@@ -29,6 +30,7 @@ public class MemberDto {
         private String name;
         private String displayName;
         private String phoneNumber;
+        private String memberStatus;
 
     }
 }

--- a/server/src/main/java/com/book/village/server/domain/member/mapper/MemberMapper.java
+++ b/server/src/main/java/com/book/village/server/domain/member/mapper/MemberMapper.java
@@ -7,5 +7,18 @@ import org.mapstruct.Mapper;
 @Mapper(componentModel = "spring")
 public interface MemberMapper {
     Member patchMemberDtoToMember(MemberDto.Patch memberDto);
-    MemberDto.Response memberToResponseMemberDto(Member member);
+    default MemberDto.Response memberToResponseMemberDto(Member member){
+        if (member == null) {
+            return null;
+        } else {
+            MemberDto.Response.ResponseBuilder response = MemberDto.Response.builder();
+            response.memberId(member.getMemberId());
+            response.email(member.getEmail());
+            response.name(member.getName());
+            response.displayName(member.getDisplayName());
+            response.phoneNumber(member.getPhoneNumber());
+            response.memberStatus(member.getMemberStatus().getStatus());
+            return response.build();
+        }
+    };
 }

--- a/server/src/main/java/com/book/village/server/domain/member/service/MemberService.java
+++ b/server/src/main/java/com/book/village/server/domain/member/service/MemberService.java
@@ -60,6 +60,10 @@ public class MemberService {
     public Member updateMember(Member member, Member patchMember) {
         return customBeanUtils.copyNonNullProperties(patchMember, member);
     }
+    public void quitMember(String email){
+        Member findMember = findMember(email);
+        findMember.setMemberStatus(Member.MemberStatus.MEMBER_QUIT);
+    }
 
     public void registerLogoutToken(String jws) {
         ValueOperations valueOperations = redisTemplate.opsForValue();

--- a/server/src/main/java/com/book/village/server/global/exception/ExceptionCode.java
+++ b/server/src/main/java/com/book/village/server/global/exception/ExceptionCode.java
@@ -8,6 +8,7 @@ public enum ExceptionCode {
 
     TITLE_NONE(400, "TITLE_NONE"),
     MEMBER_NOT_FOUND(404, "member not found"),
+    MEMBER_STATUS_QUIT(404, "member status is quit"),
 
     MEMBER_DUPLICATE(409, "MEMBER_DUPLICATE"),
     ALREADY_LOGOUT_MEMBER(409, "already logout member"),


### PR DESCRIPTION
### 작업한 내용
- 새로 방문한 회원이면 query param으로 membership을 new / existing으로 전달
- main으로 토큰 전달
- 멤버 탈퇴는 회원 상태를 탈퇴 상태로만 변경
- 회원 탈퇴하면 접근 못하도록 예외처리하여 unauthorized 표시 반환
### 보충할 내용
- 테스트 케이스 작성 및 member API 문서 작성
- 유효성 검사 규칙 정하기